### PR TITLE
script to make empty lock cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ The default cursor file is placed at
 resistant against maliciously crafted files. Therfore do not open
 ``pickle`` files from untrusted sources as they may compromise your
 system. The default padlock file is created on install (by
-``make_default_lock.py``).
+``make_default_lock.py``). In case you do not want to see any kind
+of cursor, an empty one can be created using make_empty_lock.py.
 
 Requirements
 ------------

--- a/make_empty_lock.py
+++ b/make_empty_lock.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python3
+
+import pickle
+import sys
+
+fg_bitmap = bytes([0x00])
+bg_bitmap = bytes([0x00])
+
+with open("lock.pickle", "wb") as f:
+    pickle.dump({
+            "width": 1,
+            "height": 1,
+            "x_hot": 1,
+            "y_hot": 1,
+            "fg_bitmap": fg_bitmap,
+            "bg_bitmap": bg_bitmap,
+            "color_mode": "named",
+            "bg_color": "steelblue3",
+            "fg_color": "grey25"
+    }, f)

--- a/make_empty_lock.py
+++ b/make_empty_lock.py
@@ -1,20 +1,19 @@
 #!/usr/bin/python3
 
 import pickle
-import sys
 
 fg_bitmap = bytes([0x00])
 bg_bitmap = bytes([0x00])
 
 with open("lock.pickle", "wb") as f:
     pickle.dump({
-            "width": 1,
-            "height": 1,
-            "x_hot": 1,
-            "y_hot": 1,
-            "fg_bitmap": fg_bitmap,
-            "bg_bitmap": bg_bitmap,
-            "color_mode": "named",
-            "bg_color": "steelblue3",
-            "fg_color": "grey25"
+        "width": 1,
+        "height": 1,
+        "x_hot": 1,
+        "y_hot": 1,
+        "fg_bitmap": fg_bitmap,
+        "bg_bitmap": bg_bitmap,
+        "color_mode": "named",
+        "bg_color": "steelblue3",
+        "fg_color": "grey25"
     }, f)


### PR DESCRIPTION
I assume I am not the only one who just wants the screen to be locked but not see any kind of indication of that fact. Since converting an empty image was surprisingly complicated, I added a quick script to create an empty cursor and a corresponding note in the README.