### PR TITLE
Refuse running in a wayland session

### DIFF
--- a/bin/pyxtrlock
+++ b/bin/pyxtrlock
@@ -13,6 +13,7 @@ import simplepam as pam
 
 from pyxtrlock.cursor_file import load_cursor
 from pyxtrlock import panic
+from pyxtrlock import detect_wayland_session
 try:
     import pyxtrlock.xcb as xcb
 except ImportError as err:
@@ -22,6 +23,8 @@ try:
     import pyxtrlock.X as X
 except ImportError as err:
     panic(err)
+
+detect_wayland_session()
 
 if getpass.getuser() == 'root' and sys.argv[1:] != ['-f']:
     msg = (

--- a/bin/pyxtrlock
+++ b/bin/pyxtrlock
@@ -13,7 +13,7 @@ import simplepam as pam
 
 from pyxtrlock.cursor_file import load_cursor
 from pyxtrlock import panic
-from pyxtrlock import detect_wayland_session
+from pyxtrlock import require_x11_session
 try:
     import pyxtrlock.xcb as xcb
 except ImportError as err:
@@ -24,7 +24,7 @@ try:
 except ImportError as err:
     panic(err)
 
-detect_wayland_session()
+require_x11_session()
 
 if getpass.getuser() == 'root' and sys.argv[1:] != ['-f']:
     msg = (

--- a/pyxtrlock/__init__.py
+++ b/pyxtrlock/__init__.py
@@ -12,7 +12,7 @@ def panic(*message_parts, exit_code=1):
     sys.exit(exit_code)
 
 
-def detect_wayland_session():
+def require_x11_session():
     """
     Detect whether we're running in a Wayland session and abort if so.
     """

--- a/pyxtrlock/__init__.py
+++ b/pyxtrlock/__init__.py
@@ -32,6 +32,8 @@ def require_x11_session():
     try:
         wayland_socket.connect(os.path.join(xdg_runtime_dir, "wayland-0"))
     except OSError:
+        return
+    else:
         panic(
             "Successfully connected to Wayland socket, suspecting Wayland session. "
             "Using pyxtrlock in a Wayland session is insecure. Aborting."

--- a/pyxtrlock/__init__.py
+++ b/pyxtrlock/__init__.py
@@ -26,6 +26,12 @@ def require_x11_session():
             "Using pyxtrlock in a Wayland session is insecure. Aborting."
         )
 
+    if os.environ.get("WAYLAND_SOCKET"):
+        panic(
+            "WAYLAND_SOCKET is set, suspecting Wayland session. "
+            "Using pyxtrlock in a Wayland session is insecure. Aborting."
+        )
+
     xdg_runtime_dir = get_runtime_dir(strict=True)
     wayland_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM, 0)
 

--- a/pyxtrlock/__init__.py
+++ b/pyxtrlock/__init__.py
@@ -1,8 +1,40 @@
 
+import os
+import socket
 import sys
+
+from xdg.BaseDirectory import get_runtime_dir
 
 
 def panic(*message_parts, exit_code=1):
     """Print an error message to stderr and exit"""
     print("pyxtrlock:", *message_parts, file=sys.stderr)
     sys.exit(exit_code)
+
+
+def detect_wayland_session():
+    """
+    Detect whether we're running in a Wayland session and abort if so.
+    """
+
+    if os.environ.get("XDG_SESSION_TYPE") == "x11":
+        return
+
+    if os.environ.get("WAYLAND_DISPLAY"):
+        panic(
+            "WAYLAND_DISPLAY is set, suspecting Wayland session. "
+            "Using pyxtrlock in a Wayland session is insecure. Aborting."
+        )
+
+    xdg_runtime_dir = get_runtime_dir(strict=True)
+    wayland_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM, 0)
+
+    try:
+        wayland_socket.connect(os.path.join(xdg_runtime_dir, "wayland-0"))
+    except OSError:
+        panic(
+            "Successfully connected to Wayland socket, suspecting Wayland session. "
+            "Using pyxtrlock in a Wayland session is insecure. Aborting."
+        )
+    finally:
+        wayland_socket.close()


### PR DESCRIPTION
Pyxtrlock is insecure when running in a Wayland session, but it gives the impression to lock securely by displaying the lock icon.

This patch detects when pyxtrlock is run in a wayland session and aborts if so without displaying a lock icon.

CVE ID pending, Fixes #21.